### PR TITLE
SPOP letters 2 not working | (error) wrong number of arguments (given 2, expected 1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 gem 'sinatra', '~> 1.4.3', :require => 'sinatra/base'
 gem 'haml', '~> 4.0.0'
 gem 'sass', '~>3.2.7'
-gem 'redis', '~>3.0.0'
+gem 'redis', '~>4.2.1'
 gem 'redis-namespace', '~>1.3.1'
 gem 'rdiscount', '~>2.1.7'
 gem 'puma', '~>2.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,9 +26,9 @@ GEM
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     rdiscount (2.1.8)
-    redis (3.0.7)
+    redis (4.2.1)
     redis-namespace (1.3.2)
-      redis (~> 3.0.4)
+      redis (~> 4.2.1)
     rerun (0.11.0)
       listen (~> 3.0)
     sass (3.2.19)
@@ -50,11 +50,11 @@ DEPENDENCIES
   rack-test
   rake
   rdiscount (~> 2.1.7)
-  redis (~> 3.0.0)
+  redis (~> 4.2.1)
   redis-namespace (~> 1.3.1)
   rerun
   sass (~> 3.2.7)
   sinatra (~> 1.4.3)
 
 BUNDLED WITH
-   1.11.2
+   1.17.3

--- a/README.markdown
+++ b/README.markdown
@@ -3,16 +3,11 @@ Try Redis
 
 ---
 
-**try.redis is unmaintained since March 2018. 
-The online instance will be kept running, but won't receive updates.**
-
----
-
 
 [Try Redis](http://try.redis.io) is a demonstration of the Redis data structure server.
 
 ### Info
 
-This project was started by [@alexmchale](https://github.com/alexmchale/) back in 2010.  In January 2013 I took over the maintenance and it's running on my server since then.
+This project was started by [@alexmchale](https://github.com/alexmchale/) back in 2010.  In January 2013 [badboy](https://github.com/badboy/) took over the maintenance and hosting of the service, and in February 2020 [antirez](https://github.com/antirez/). It is now being maintained by the [Redis community](https://redis.io/community).
 
-Contributions, improvements, comments and suggestions welcome. Just file an [issue](https://github.com/badboy/try.redis/issues).
+Contributions, improvements, comments and suggestions welcome. Just file an [issue](https://github.com/redis/try.redis/issues).

--- a/test/test_try_redis.rb
+++ b/test/test_try_redis.rb
@@ -99,7 +99,7 @@ class TestTryRedis < MiniTest::Test
 
   def test_eval_responds_to_tutorial
     command "tutorial"
-    body_was :notification, "<p>Redis is what is called a key-value store"
+    body_was :notification, "<p>Redis is in the family of databases"
   end
 
   def test_eval_responds_to_prev
@@ -109,13 +109,13 @@ class TestTryRedis < MiniTest::Test
 
   def test_eval_responds_to_next
     command "next"
-    response_was(/{"notification":"<p>Redis is what is called a key-value store/)
-    body_was :notification, "<p>Redis is what is called a key-value store"
+    response_was(/{"notification":"<p>Redis is in the family of databases/)
+    body_was :notification, "<p>Redis is in the family of databases"
   end
 
   def test_eval_responds_to_tutorial_id
     command "t2"
-    body_was :notification, "<p>Other common operations provided"
+    body_was :notification, "<p>Other basic operations provided by Redis"
   end
 
   def test_eval_responds_to_namespace
@@ -379,9 +379,9 @@ class TestTryRedis < MiniTest::Test
       command_with_body "ZREMRANGEBYLEX myzset [b [d", response: "(integer) 3"
       assert_equal 4, @r.zcard("lex:myzset")
 
-      command_with_body "zlexcount", error: /ERR wrong number of arguments for 'zlexcount' command/
-      command_with_body "zlexcount a", error: /ERR wrong number of arguments for 'zlexcount' command/
-      command_with_body "zlexcount a b c d", error: /ERR wrong number of arguments for 'zlexcount' command/
+      command_with_body "zlexcount", error: /\(error\) wrong number of arguments \(given 1, expected 3\)/
+      command_with_body "zlexcount a", error: /\(error\) wrong number of arguments \(given 1, expected 3\)/
+      command_with_body "zlexcount a b c d", error: /\(error\) wrong number of arguments \(given 4, expected 3\)/
     end
   end
 

--- a/tutorial/07.markdown
+++ b/tutorial/07.markdown
@@ -12,12 +12,12 @@ client at the same time, elements in the head or the tail of the list.
 [RPOP](#help) removes the last element from the list and returns it.
 
 <pre><code>
-    <a href="#run">RPOP friends</a> => "3"
+    <a href="#run">RPOP friends</a> => "Bob"
 </code></pre>
 
-Note that the list now only has four elements:
+Note that the list now only has one element:
 
 <pre><code>
-    <a href="#run">LLEN friends</a> => 4
-    <a href="#run">LRANGE friends 0 -1</a> => 1) "Alice" 2) "Bob" 3) "1" 4) "2"
+    <a href="#run">LLEN friends</a> => 1
+    <a href="#run">LRANGE friends 0 -1</a> => 1) "Alice"
 </code></pre>

--- a/tutorial/08.markdown
+++ b/tutorial/08.markdown
@@ -1,7 +1,7 @@
 Both [RPUSH](#help) and [LPUSH](#help) commands are variadic, so you can specify multiple elements in the same command execution.
 
 <pre><code>
-    <a href="#run">RPUSH friends 1 2 3</a> => 6
+    <a href="#run">RPUSH friends 1 2 3</a> => 4
 </code></pre>
 
 <span class="tip">
@@ -11,6 +11,6 @@ Tip: RPUSH and LPUSH return the total length of the list after the operation.
 You can also use [LLEN](#help) to obtain the current length of the list.
 
 <pre><code>
-    <a href="#run">LLEN friends</a> => 6
+    <a href="#run">LLEN friends</a> => 4
 </code></pre>
 

--- a/views/index.haml
+++ b/views/index.haml
@@ -1,13 +1,21 @@
 %html
 
   %head
-
+    :javascript
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-T6QK835');
     %title Try Redis
     %link{"rel" => "shortcut icon", "href" => "/images/favicon.png"}
     %link{"rel" => "stylesheet", "href" => "/style.css"}
 
   %body
-
+    %noscript
+      %iframe(src="https://www.googletagmanager.com/ns.html?id=GTM-T6QK835"
+              height="0" width="0"
+              style="display:none;visibility:hidden")
     #header
       %img{"src" => "/images/try-redis-500x50.png", "width" => 500, "height" => 50}
 
@@ -21,8 +29,8 @@
     #footer
       :markdown
         This site is open source software, you can find
-        the current version [here](https://github.com/antirez/try.redis).
-        It's now maintained and hosted by [antirez](https://twitter.com/antirez).
+        the current version [here](https://github.com/redis/try.redis).
+        It's now maintained by the [Redis community](https://redis.io/community) and hosted by Redis Labs.
 
     %script{"type" => "application/x-javascript", "src" => "/javascripts/jquery.min.js"}
     %script{"type" => "application/x-javascript", "src" => "/javascripts/underscore-min.js"}


### PR DESCRIPTION
```
Sets also have a command very similar to LPOP and RPOP in order to extract elements from the set and return them to the client in a single operation. However since sets are not ordered data structures the returned (and removed) elements are totally casual in this case.


    SADD letters a b c d e f => 6
    SPOP letters 2 => 1) "c" 2) "a"

```

Clicked on both of the commands and got this error:

> SADD letters a b c d e f
(integer) 6
> SPOP letters 2
(error) wrong number of arguments (given 2, expected 1)

What did I do wrong?
